### PR TITLE
images and text mix quick fix

### DIFF
--- a/hexaflip.coffee
+++ b/hexaflip.coffee
@@ -158,6 +158,7 @@ class window.HexaFlip
       el.innerHTML = ''
       el.style.backgroundImage = "url(#{ value })"
     else
+      el.style.backgroundImage = "none"
       el.innerHTML = value
 
 


### PR DESCRIPTION
Thanks for fixing the webkit touch events, here's a fix for the mix of images and text in your cubes. The background image was sticking around old faces on the cube, now it's set to none if value is not a url. 
